### PR TITLE
Fixes configuration constant names used inside .sh file

### DIFF
--- a/config.example.tcl
+++ b/config.example.tcl
@@ -2,8 +2,8 @@
 # Please make sure that all values are set properly.
 
 ## Remote and Local filesystem paths
-set EXPORT_TO_FOLDER "/path/to/folder"
-set DOWNLOAD_TO_FOLDER "/path/to/folder"
+set EXPORT_FOLDER "/path/to/folder"
+set DOWNLOAD_FOLDER "/path/to/folder"
 
 ## Server Settings
 set SERVERSSH "<username>@<host.com>"


### PR DESCRIPTION
Constants used inside `./script.sh` doesn't match the ones defined inside a sample `config.example.tcl`, what throws an error while running the script.
This pull request is supposed to fix the problem, so other people doesn't face it using sample configuration file.
